### PR TITLE
Unduplicating Mosaic shortcut

### DIFF
--- a/desktop.patch
+++ b/desktop.patch
@@ -1,49 +1,32 @@
-diff -ur ../puzzles-20230313.adf2a09/cmake/platforms/unix.cmake ./cmake/platforms/unix.cmake
---- ../puzzles-20230313.adf2a09/cmake/platforms/unix.cmake	2023-03-13 03:30:02.000000000 +0200
-+++ ./cmake/platforms/unix.cmake	2023-03-19 23:36:58.932379628 +0200
-@@ -109,10 +109,12 @@
+--- unix.cmake	2025-01-22 12:59:52.050127544 +0700
++++ ./cmake/platforms/unix.cmake	2025-01-22 15:12:22.388879851 +0700
+@@ -109,15 +109,15 @@
        # CMAKE_INSTALL_BINDIR.
        install(TARGETS ${TARGET})
      endif()
 -    configure_file(${CMAKE_SOURCE_DIR}/puzzle.desktop.in ${binary_name}.desktop)
 +    configure_file(${CMAKE_SOURCE_DIR}/puzzle.desktop.in uk.org.greenend.chiark.sgtatham.puzzles.${binary_name}.desktop)
-     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/icons/${NAME}-48d24.png
--      DESTINATION share/pixmaps OPTIONAL RENAME ${binary_name}-48d24.png)
+     foreach(icon_size ${all_icon_sizes})
+       install(
+         FILES ${CMAKE_CURRENT_BINARY_DIR}/icons/${NAME}-${icon_size}d24.png
+         DESTINATION share/icons/hicolor/${icon_size}x${icon_size}/apps
+         OPTIONAL
+-        RENAME ${binary_name}.png)
++        RENAME uk.org.greenend.chiark.sgtatham.puzzles.${binary_name}.png)
+     endforeach()
 -    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${binary_name}.desktop
-+      DESTINATION share/pixmaps OPTIONAL RENAME uk.org.greenend.chiark.sgtatham.puzzles.${binary_name}-48d24.png)
-+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/icons/${NAME}-96d24.png
-+      DESTINATION share/icons/hicolor/96x96/apps/ OPTIONAL RENAME uk.org.greenend.chiark.sgtatham.puzzles.${binary_name}.png)
 +    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/uk.org.greenend.chiark.sgtatham.puzzles.${binary_name}.desktop
        DESTINATION share/applications)
    endif()
  endfunction()
-diff -ur ../puzzles-20230313.adf2a09/puzzle.desktop.in ./puzzle.desktop.in
---- ../puzzles-20230313.adf2a09/puzzle.desktop.in	2023-03-13 03:30:02.000000000 +0200
-+++ ./puzzle.desktop.in	2023-03-19 23:25:30.809299623 +0200
+--- puzzle.desktop.in	2025-01-22 12:59:52.067127580 +0700
++++ ./puzzle.desktop.in	2025-01-22 15:21:24.837795300 +0700
 @@ -4,7 +4,7 @@
  Name=${displayname}
  Comment=${description}
  Exec=${binary_name}
--Icon=${binary_name}-48d24
+-Icon=${binary_name}
 +Icon=uk.org.greenend.chiark.sgtatham.puzzles.${binary_name}
  StartupNotify=false
  Categories=Game;LogicGame;
  Terminal=false
-diff -ur ../puzzles-20230313.adf2a09/icons/icons.cmake ./icons/icons.cmake
---- ../puzzles-20230313.adf2a09/icons/icons.cmake
-+++ ./icons/icons.cmake
-@@ -81,12 +81,13 @@ set(untangle_crop 320x320 164x164+3+116)
- add_custom_target(icons)
- 
- # All sizes of icon we make for any purpose.
--set(all_icon_sizes 96 88 48 44 32 16)
-+set(all_icon_sizes 128 96 88 48 44 32 16)
- 
- # Sizes of icon we put into the Windows .ico files.
- set(win_icon_sizes 48 32 16)
- 
- # Border thickness for each icon size.
-+set(border_128 6)
- set(border_96 4)
- set(border_88 4)
- set(border_48 4)

--- a/uk.org.greenend.chiark.sgtatham.puzzles.metainfo.xml
+++ b/uk.org.greenend.chiark.sgtatham.puzzles.metainfo.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<component type="desktop">
+<component type="desktop-application">
   <id>uk.org.greenend.chiark.sgtatham.puzzles</id>
   <project_license>MIT</project_license>
   <metadata_license>MIT</metadata_license>
   <name>Simon Tatham's Portable Puzzle Collection</name>
   <summary>Puzzle game collection</summary>
+  <developer id="uk.org.greenend.chiark.sgtatham">
+  	<name>Simon Tatham</name>
+  </developer>
+  <launchable type="desktop-id">uk.org.greenend.chiark.sgtatham.puzzles.desktop</launchable>
   <description>
     <p>Simon Tatham's Portable Puzzle Collection contains a number of popular puzzle games for a single player.  It currently consists of these games:.</p>
     <ul>
@@ -67,7 +71,7 @@
     <category>LogicGame</category>
   </categories>
   <releases>
-    <release version="20230408" date="2023-04-08" />
+    <release version="20241229" date="2024-12-29" />
   </releases>
   <requires>
     <internet>offline-only</internet>

--- a/uk.org.greenend.chiark.sgtatham.puzzles.yaml
+++ b/uk.org.greenend.chiark.sgtatham.puzzles.yaml
@@ -48,6 +48,8 @@ modules:
       - install -Dm644 uk.org.greenend.chiark.sgtatham.puzzles.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
       - install -Dm644 icons/mosaic-128d24.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/uk.org.greenend.chiark.sgtatham.puzzles.png
       - desktop-file-edit --set-icon=uk.org.greenend.chiark.sgtatham.puzzles uk.org.greenend.chiark.sgtatham.puzzles.mosaic.desktop
+      - desktop-file-edit --set-name="Simon Tatham's Puzzles" uk.org.greenend.chiark.sgtatham.puzzles.mosaic.desktop
+      - desktop-file-edit --set-comment="Portable puzzles collection" uk.org.greenend.chiark.sgtatham.puzzles.mosaic.desktop  
       - install -Dm644 uk.org.greenend.chiark.sgtatham.puzzles.mosaic.desktop ${FLATPAK_DEST}/share/applications/uk.org.greenend.chiark.sgtatham.puzzles.desktop
     sources:
       - type: git
@@ -57,4 +59,3 @@ modules:
         path: desktop.patch
       - type: file
         path: uk.org.greenend.chiark.sgtatham.puzzles.metainfo.xml
-

--- a/uk.org.greenend.chiark.sgtatham.puzzles.yaml
+++ b/uk.org.greenend.chiark.sgtatham.puzzles.yaml
@@ -1,6 +1,6 @@
-app-id: uk.org.greenend.chiark.sgtatham.puzzles 
+app-id: uk.org.greenend.chiark.sgtatham.puzzles
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: mosaic
 finish-args:
@@ -37,8 +37,8 @@ modules:
       - --with-openjp2
     sources:
       - type: archive
-        url: https://github.com/ImageMagick/ImageMagick6/archive/6.9.10-23.tar.gz
-        sha256: 2a0b11952c994b06562dace16a53c01bdd0f715de59483145eb3053902a42361
+        url: https://github.com/ImageMagick/ImageMagick6/archive/6.9.13-21.tar.gz
+        sha256: 36a7205c73db9107acec5bb7594e3afbde3cc08a89f0a22a15eead387244fa05
     # We need it only for the build stage
     cleanup:
       - '*'
@@ -52,7 +52,7 @@ modules:
     sources:
       - type: git
         url: https://git.tartarus.org/simon/puzzles.git
-        commit: d505f08f671c2f0a3fdd0b7d733e4ce987aa4786
+        commit: 79be403101d055d2fde3611a5f133135d4094ee9
       - type: patch
         path: desktop.patch
       - type: file


### PR DESCRIPTION
An attempt to stop having duplicate Mosaic shortcuts in the application menu - by changing the name/desc of `uk.org.greenend.chiark.sgtatham.puzzles.desktop` instead of having it be a straight copy of `uk.org.greenend.chiark.sgtatham.puzzles.mosaic.desktop`